### PR TITLE
Move api key usage proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ proxy:
       target: https://api.signadot.com
       credentials: require
       changeOrigin: true
-      apiKey: ${SIGNADOT_API_KEY}
+      headers:
+        Signadot-Api-Key: ${SIGNADOT_API_KEY}
       allowedHeaders:
         - 'signadot-api-key'
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ proxy:
       target: https://api.signadot.com
       credentials: require
       changeOrigin: true
+      apiKey: ${SIGNADOT_API_KEY}
       allowedHeaders:
         - 'signadot-api-key'
 ```

--- a/config.d.ts
+++ b/config.d.ts
@@ -19,11 +19,5 @@ export interface Config {
      * @visibility frontend
      */
     org: string;
-
-    /**
-     * API key
-     * @visibility frontend
-     */
-    apiKey: string;
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signadot-lib/backstage-plugin",
-  "version": "0.1.10-xrc.6",
+  "version": "0.1.10-xrc.7",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/src/api.ts
+++ b/src/api.ts
@@ -77,14 +77,12 @@ export class SignadotEnvironmentsApiImpl implements SignadotEnvironmentsApi {
   }) {
     const apiUrl = options.configApi.getOptionalString("signadot.apiUrl") ?? "https://api.signadot.com";
     const org = options.configApi.getString("signadot.org");
-    const apiKey = options.configApi.getString("signadot.apiKey");
 
     this.apiUrl = apiUrl;
     this.org = org;
     this.discoveryApi = options.discoveryApi;
     this.fetchApi = options.fetchApi;
     this.headers = {
-      "signadot-api-key": apiKey,
       "Content-Type": "application/json",
     };
   }

--- a/src/hooks/useDataFetching.ts
+++ b/src/hooks/useDataFetching.ts
@@ -27,7 +27,7 @@ export function useDataFetching<T>(
   } = options;
 
   const hasInitialFetch = useRef(false);
-  const fetchDataRef = useRef<() => Promise<void>>();
+  const fetchDataRef = useRef<() => Promise<void>>(() => Promise.resolve());
 
   const [state, setState] = useState<DataFetchingState<T>>({
     data: initialData,


### PR DESCRIPTION
Move the API key from the plugin frontend to the proxy config, as recommended in the [official Backstage upstream PR](https://github.com/backstage/backstage/pull/30485#issuecomment-3073654515).

If necessary, we can later switch to using a backend plugin if usage justifies it. For now, this approach should be a solid starting point.